### PR TITLE
feat: avoid trigger increment-views call in link component prefetch

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,5 +36,13 @@ export function middleware(request, event) {
 }
 
 export const config = {
-  matcher: '/writing/:path/'
-}
+  matcher: [
+    {
+      source: "/writing/:path/",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -38,10 +38,10 @@ export function middleware(request, event) {
 export const config = {
   matcher: [
     {
-      source: "/writing/:path/",
+      source: '/writing/:path/',
       missing: [
-        { type: "header", key: "next-router-prefetch" },
-        { type: "header", key: "purpose", value: "prefetch" },
+      { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
       ],
     },
   ],

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -40,9 +40,9 @@ export const config = {
     {
       source: '/writing/:path/',
       missing: [
-      { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
-      ],
-    },
-  ],
-};
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi there,

When I forked this project, I encountered an issue in production mode - the `increment_view_count` RPC is triggered in the `/writing` route due to Link prefetching. The middleware function looks fine and only runs on `/writing/:path/`.

The problem is caused by Next.js's Link component prefetching all linked pages to improve UX.

To fix this, I had to differentiate between prefetched and normal user-initiated requests. I found that the solution in [this discussion](https://github.com/vercel/next.js/discussions/37736#discussioncomment-7274460) solves the prefetch issue nicely.

Apologies for the trouble, and thanks for this amazing work! Your blog looks concise and smooth.