### PR TITLE
fix: update logic to handle index of 0

### DIFF
--- a/src/hooks/useViewData.js
+++ b/src/hooks/useViewData.js
@@ -27,7 +27,7 @@ export const useViewData = (slug) => {
         setViewData((prev) => {
           if (!prev) return null
           const index = prev.findIndex((item) => item.slug === payload.new.slug)
-          if (index) index !== -1 ? (prev[index] = payload.new) : prev.push(payload.new)
+          index !== -1 ? (prev[index] = payload.new) : prev.push(payload.new)
           return [...prev]
         })
       }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,5 +36,13 @@ export function middleware(request, event) {
 }
 
 export const config = {
-  matcher: '/writing/:path/'
-}
+  matcher: [
+    {
+      source: "/writing/:path/",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -38,10 +38,10 @@ export function middleware(request, event) {
 export const config = {
   matcher: [
     {
-      source: "/writing/:path/",
+      source: '/writing/:path/',
       missing: [
-        { type: "header", key: "next-router-prefetch" },
-        { type: "header", key: "purpose", value: "prefetch" },
+      { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
       ],
     },
   ],

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -40,9 +40,9 @@ export const config = {
     {
       source: '/writing/:path/',
       missing: [
-      { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' },
-      ],
-    },
-  ],
-};
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi there,

I noticed that when the index equals 0, the update logic is not triggered, which seems incorrect.

The `if (index)` check appears unnecessary and could be removed to fix this bug. Deleting that line would allow the update to correctly run even when index is 0.